### PR TITLE
add verify_ssl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ HACS does not "configure" the integration for you, You must add OpenWebUI Conver
   * **Base Url** is the URL for the OpenWebUI service.
   * **API Key** is the API key for your user, which you can find in your OpenWebUI Settings, under Account.
   * **API Timeout** is described below under General Settings.
+  * **Verify SSL** verify SSL certificate for https. Disable verification if you are using self signed certificates.
 * Once you have added the integration, make sure you set your preferred model as described below.
 
 ## Options

--- a/custom_components/openwebui_conversation/__init__.py
+++ b/custom_components/openwebui_conversation/__init__.py
@@ -27,8 +27,10 @@ from .const import (
     CONF_API_KEY,
     CONF_TIMEOUT,
     CONF_MODEL,
+    CONF_VERIFY_SSL,
     DEFAULT_TIMEOUT,
     DEFAULT_MODEL,
+    DEFAULT_VERIFY_SSL,
 )
 from .conversation import OpenWebUIAgent
 from .coordinator import OpenWebUIDataUpdateCoordinator
@@ -46,6 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         api_key=entry.data[CONF_API_KEY],
         timeout=entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
         session=async_get_clientsession(hass),
+        verify_ssl=entry.options.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
     )
 
     hass.data[DOMAIN][entry.entry_id] = coordinator = OpenWebUIDataUpdateCoordinator(

--- a/custom_components/openwebui_conversation/api.py
+++ b/custom_components/openwebui_conversation/api.py
@@ -19,12 +19,14 @@ class OpenWebUIApiClient:
         base_url: str,
         api_key: str,
         timeout: int,
+        verify_ssl: bool,
         session: aiohttp.ClientSession,
     ) -> None:
         """Sample API Client."""
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self.timeout = timeout
+        self._verify_ssl = verify_ssl
         self._session = session
 
     async def async_get_heartbeat(self) -> bool:
@@ -104,6 +106,7 @@ class OpenWebUIApiClient:
                     url=url,
                     headers=headers,
                     json=data,
+                    verify_ssl=self._verify_ssl,
                 )
 
                 if response.status == 404 and decode_json:

--- a/custom_components/openwebui_conversation/config_flow.py
+++ b/custom_components/openwebui_conversation/config_flow.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_SEARCH_ENABLED,
     CONF_SEARCH_SENTENCES,
     CONF_SEARCH_RESULT_PREFIX,
+    CONF_VERIFY_SSL,
     DEFAULT_SERVICE_NAME,
     DEFAULT_BASE_URL,
     DEFAULT_TIMEOUT,
@@ -46,6 +47,7 @@ from .const import (
     DEFAULT_SEARCH_ENABLED,
     DEFAULT_SEARCH_SENTENCES,
     DEFAULT_SEARCH_RESULT_PREFIX,
+    DEFAULT_VERIFY_SSL,
 )
 from .exceptions import ApiClientError, ApiCommError, ApiTimeoutError
 
@@ -60,6 +62,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
             ),
         ),
         vol.Required(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int,
+        vol.Required(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
     }
 )
 
@@ -103,6 +106,7 @@ class OpenWebUIConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 api_key=user_input[CONF_API_KEY],
                 timeout=user_input[CONF_TIMEOUT],
                 session=async_create_clientsession(self.hass),
+                verify_ssl=user_input[CONF_VERIFY_SSL],
             )
             response = await self.client.async_get_heartbeat()
             if not response:
@@ -124,7 +128,10 @@ class OpenWebUIConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_BASE_URL: user_input[CONF_BASE_URL],
                     CONF_API_KEY: user_input[CONF_API_KEY],
                 },
-                options={CONF_TIMEOUT: user_input[CONF_TIMEOUT]},
+                options={
+                    CONF_TIMEOUT: user_input[CONF_TIMEOUT],
+                    CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
+                },
             )
 
         return self.async_show_form(
@@ -180,6 +187,7 @@ class OpenWebUIOptionsFlow(config_entries.OptionsFlow):
                 api_key=self.config_entry.data[CONF_API_KEY],
                 timeout=self.config_entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
                 session=async_create_clientsession(self.hass),
+                verify_ssl=self.config_entry.options.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
             )
             response = await client.async_get_models()
             models = response["data"]

--- a/custom_components/openwebui_conversation/const.py
+++ b/custom_components/openwebui_conversation/const.py
@@ -20,6 +20,7 @@ CONF_LANGUAGE_CODE = "lang_code"
 CONF_SEARCH_ENABLED = "search_enabled"
 CONF_SEARCH_SENTENCES = "search_sentences"
 CONF_SEARCH_RESULT_PREFIX = "search_result_prefix"
+CONF_VERIFY_SSL = "verify_ssl"
 
 DEFAULT_SERVICE_NAME = "OpenWebUI"
 DEFAULT_BASE_URL = "http://openwebui.homeassistant.local"
@@ -30,3 +31,4 @@ DEFAULT_SEARCH_ENABLED = False
 DEFAULT_SEARCH_SENTENCES = """look up {query}
 search [the web | the internet] for {query}"""
 DEFAULT_SEARCH_RESULT_PREFIX = "Based on a search of the internet: "
+DEFAULT_VERIFY_SSL = True

--- a/custom_components/openwebui_conversation/conversation.py
+++ b/custom_components/openwebui_conversation/conversation.py
@@ -33,12 +33,14 @@ from .const import (
     CONF_SEARCH_ENABLED,
     CONF_SEARCH_SENTENCES,
     CONF_SEARCH_RESULT_PREFIX,
+    CONF_VERIFY_SSL,
     DEFAULT_TIMEOUT,
     DEFAULT_MODEL,
     DEFAULT_LANGUAGE_CODE,
     DEFAULT_SEARCH_ENABLED,
     DEFAULT_SEARCH_SENTENCES,
     DEFAULT_SEARCH_RESULT_PREFIX,
+    DEFAULT_VERIFY_SSL,
 )
 from .exceptions import ApiCommError, ApiJsonError, ApiTimeoutError
 from .message import Message
@@ -69,6 +71,7 @@ class OpenWebUIAgent(
             api_key=entry.data[CONF_API_KEY],
             timeout=entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
             session=async_get_clientsession(hass),
+            verify_ssl=entry.options.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
         )
         self.history: dict[str, list[Message]] = {}
         self.search_enabled = entry.options.get(

--- a/custom_components/openwebui_conversation/strings.json
+++ b/custom_components/openwebui_conversation/strings.json
@@ -6,7 +6,8 @@
                     "service_name": "Service Name",
                     "base_url": "Base Url",
                     "api_key": "API Key",
-                    "timeout": "API Timeout"
+                    "timeout": "API Timeout",
+                    "verify_ssl": "Verify SSL"
                 }
             }
         },

--- a/custom_components/openwebui_conversation/translations/en.json
+++ b/custom_components/openwebui_conversation/translations/en.json
@@ -6,7 +6,8 @@
                     "service_name": "Service Name",
                     "base_url": "Base Url",
                     "api_key": "API Key",
-                    "timeout": "API Timeout"
+                    "timeout": "API Timeout",
+                    "verify_ssl": "Verify SSL"
                 }
             }
         },


### PR DESCRIPTION
This PR adds a "Verify SSL" option to the initial configuration.  Disabling the Verify SSL option allows for connecting to Open WebUI installations that are using self signed certificates for https.  The default selection for "Verify SSL" is enabled.